### PR TITLE
Makefile: Fix INCLUDES variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
 # outdated
-INCLUDES := -I$(OUTPUT) -I../../libbpf/include/uapi
+INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi
 CFLAGS := -g -Wall -DVERISTAT_VERSION=\"$(VERISTAT_VERSION)\" -O$(if $(DEBUG),0,2)
 ALL_CFLAGS := $(CFLAGS) $(EXTRA_CFLAGS)
 ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)


### PR DESCRIPTION
The INCLUDES variable does NOT point to libbpf UAPI headers correctly
and causes build failure on old kernels.