### PR TITLE
Add release workflow for shipping binaries and combined sources (veristat+libbpf)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,96 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build static veristat binary
+    runs-on: ubuntu-22.04
+    env:
+      TARGETARCH: ${{ matrix.arch }}
+      FILE_STRING_ARCH_amd64: x86-64
+      FILE_STRING_ARCH_arm64: aarch64
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+
+    steps:
+      # amd64 needs the dependencies to build veristat
+      - name: Install dependencies (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libelf-dev
+
+      - name: Checkout veristat code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          submodules: recursive
+          path: 'veristat'
+
+      - name: Build static veristat natively for amd64
+        if: matrix.arch == 'amd64'
+        working-directory: 'veristat'
+        run: |
+          EXTRA_CFLAGS=--static \
+              make -j -C src V=1
+          strip src/veristat
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        if: matrix.arch == 'arm64'
+        with:
+          platforms: arm64
+
+      # The emulated build leverages Docker and Ubuntu 22.04 container image
+      # distribution to have all the needed arm64 packages.
+      - name: Build static veristat for arm64 with emulation
+        if: matrix.arch == 'arm64'
+        run:  |
+          docker run --platform linux/arm64 --rm -v $(pwd):/build ubuntu:22.04 \
+          bash -c "apt-get update && \
+                   apt-get install -y make pkg-config gcc libelf-dev && \
+                   cd /build/veristat && \
+                   EXTRA_CFLAGS=--static \
+                       make -j -C src V=1 && \
+                   strip src/veristat"
+
+      - name: Test veristat binary
+        working-directory: 'veristat/src'
+        env:
+          ARCH: ${{ env[format('FILE_STRING_ARCH_{0}', matrix.arch)] }}
+        run: |
+          file ./veristat | \
+              tee /dev/stderr | \
+              grep -q "${{ env.ARCH }}"
+          ./veristat --usage | grep -q Usage
+          ldd ./veristat 2>&1 | \
+              tee /dev/stderr | \
+              grep -q 'not a dynamic executable'
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ format('veristat_{0}', matrix.arch) }}
+          path: veristat/src/veristat
+
   draft-release:
     name: Create a draft release
     runs-on: ubuntu-22.04
+    needs: build
     permissions:
       contents: write
     steps:
+      - name: Download artifacts from build
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+
+      - name: Rename binaries and compress
+        run: |
+          archive_amd64="veristat-${{ github.ref_name }}-amd64.tar.gz"
+          archive_arm64="veristat-${{ github.ref_name }}-arm64.tar.gz"
+          tar -C veristat_amd64 -I 'gzip -9' -cvf "${archive_amd64}" veristat
+          tar -C veristat_arm64 -I 'gzip -9' -cvf "${archive_arm64}" veristat
+          sha256sum "${archive_amd64}" > "${archive_amd64}.sha256sum"
+          sha256sum "${archive_arm64}" > "${archive_arm64}.sha256sum"
+
       - name: Checkout veristat and libbpf code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    name: Create a draft release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout veristat and libbpf code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          submodules: recursive
+          path: 'veristat'
+
+      - name: Package source code including submodules
+        run: |
+          tar -I 'gzip -9' --exclude-vcs \
+              -cvf "veristat-all-sources-${{ github.ref_name }}.tar.gz" veristat
+
+      - name: Create draft release and add artifacts
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: true
+          files: veristat*

--- a/scripts/gh-label-release-assets.sh
+++ b/scripts/gh-label-release-assets.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Use this script to add labels to GitHub release assets for a given release.
+#
+# Based on the following console workflow:
+#
+# gh api \
+#     '/repos/libbpf/veristat/releases/tags/<some_tag>' \
+#     --jq '.id'
+# gh api \
+#     '/repos/libbpf/veristat/releases/<release_id>/assets' \
+#     --jq '.[] | select(.name == "<file_name>").id'
+# gh api \
+#     --method PATCH \
+#     -H "Accept: application/vnd.github+json" \
+#     -H "X-GitHub-Api-Version: 2022-11-28" \
+#     '/repos/libbpf/veristat/releases/assets/<asset_id>' \
+#     -f name='<new_file_name>' \
+#     -f label='<new_name_in_asset_list>'
+
+REPO="libbpf/veristat"
+
+usage() {
+    echo "Update asset labels for veristat releases"
+    echo "Usage:"
+    echo "  $0 [options] <release_tag>"
+    echo ""
+    echo "OPTIONS"
+    echo " -h       display this help"
+    exit "$1"
+}
+
+OPTIND=1
+while getopts "h" opt; do
+    case "$opt" in
+    h)
+        usage 0
+        ;;
+    *)
+        usage 1
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+[[ "${1:-}" = "--" ]] && shift
+
+# Get release tag from command line
+if [[ "$#" -lt 1 ]]; then
+    echo "error: missing release tag"
+    usage 1
+fi
+release_tag="$1"
+echo "repo: ${REPO}, release tag: ${release_tag}"
+
+# Add labels to set for given asset names here:
+declare -A assets_labels=(
+    ["veristat-all-sources-${release_tag}.tar.gz"]="Full source code with submodules (tar.gz)"
+)
+
+# Get release ID
+release_id="$(gh api "/repos/${REPO}/releases/tags/${release_tag}" --jq '.id')"
+echo "  found release ID ${release_id}"
+
+# For each label to set, get asset ID, prompt user for confirmation, set label
+for asset_name in "${!assets_labels[@]}"; do
+    asset_id="$(gh api "/repos/${REPO}/releases/${release_id}/assets" \
+        --jq ".[] | select(.name == \"${asset_name}\").id")"
+    echo "  found asset ID ${asset_id}"
+
+    echo "asset '${asset_name}': add label '${assets_labels[${asset_name}]}'"
+    answer=""
+    read -rp 'proceed? [y/N]: ' answer
+
+    case "${answer}" in
+        y|yes|Y|Yes|YES)
+            # Note: A 404 error at this stage may be synonymous with
+            # insufficient permissions for the token in use for gh.
+            gh api \
+                --method PATCH \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "/repos/${REPO}/releases/assets/${asset_id}" \
+                -f label="${assets_labels[${asset_name}]}"
+            ;;
+        *)
+            echo "cancelled"
+            ;;
+    esac
+done


### PR DESCRIPTION
Add a new GitHub workflow that runs when new tags are pushed. This workflow creates a draft release based on the tag, that a user can then publish. It adds assets to this draft release: a tarball containing the combined sources of veristat _and_ its libbpf submodule, for ease of packaging (first commit), and binaries for amd64 and arm64, built statically (second commit). The third commit is a script to rename some assets on the release page.

I can discard some of the commits if you're not interested, obviously.

Note that the release author on the GitHub interface will appear as `github-actions`, and not as the person who finalises and publishes the release. This probably does not matter at all.

- [Sample run](https://github.com/qmonnet/veristat/actions/runs/4835440111/jobs/8617746607) (2m 36s)
- [Sample release](https://github.com/qmonnet/veristat/releases/tag/test03)

Some items that are _not_ part of the PR:

- Shipping combined sources as a .zip (we're just doing .tar.gz, but adding a .zip would be trivial)
- Shipping binaries for archs other than amd64, arm64
- Shipping signed binaries
- Filtering tags so that the workflow runs only on a subset of tags (e.g. `'v[0-9]+.[0-9]+'` instead of `'**'`
- Removing `scripts/archive-srcs-full.sh`

This derives from the release workflow in use for bpftool, [developed in collaboration with Mahé Tardy](https://github.com/libbpf/bpftool/pull/84).