### PR TITLE
ci: Use dedicated GitHub Action to package sources in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,9 +107,10 @@ jobs:
           path: 'veristat'
 
       - name: Package source code including submodules
-        run: |
-          tar -I 'gzip -9' --exclude-vcs \
-              -cvf "veristat-all-sources-${{ github.ref_name }}.tar.gz" veristat
+        uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a # v1.0.1
+        with:
+          output-files: veristat-all-sources-${{ github.ref_name }}.tar.gz
+          base-repo: veristat
 
       - name: Create draft release and add artifacts
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15


### PR DESCRIPTION
Follow-up to #5.

Let's use a dedicated GitHub Action to package the sources of veristat plus its submodules, taking into account any "export-ignore" rule from .gitattributes files, as part of the release workflow.

This is similar to the first commit of retsnoop's equivalent PR: https://github.com/anakryiko/retsnoop/pull/44.

- [Test run](https://github.com/qmonnet/veristat/actions/runs/5131318617)
- [Resulting release](https://github.com/qmonnet/veristat/releases/tag/test05)