### PR TITLE
Update libbpf to v1.6.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-2-Clause
-VERISTAT_VERSION ?= 0.5
+VERISTAT_VERSION ?= 0.5.1
 DEBUG ?=
 
 OUTPUT := .output


### PR DESCRIPTION
libbpf release: https://github.com/libbpf/libbpf/releases/tag/v1.6.1

This update contains a libbpf fix for BPF arena relocations: https://lore.kernel.org/bpf/20250718001009.610955-1-andrii@kernel.org/